### PR TITLE
[flutter_map_cache] fix(cached tile provider): dio options overrode

### DIFF
--- a/flutter_map_cache/lib/src/cached_tile_provider.dart
+++ b/flutter_map_cache/lib/src/cached_tile_provider.dart
@@ -33,8 +33,7 @@ class CachedTileProvider extends TileProvider {
     Duration? maxStale,
     CacheKeyBuilder? keyBuilder,
     List<int>? hitCacheOnErrorExcept = defaultHitCacheOnErrorExcept,
-  }) : dio = dio ?? Dio(dioOptions) {
-    this.dio.options = dioOptions ?? BaseOptions();
+  }) : dio = dio ?? Dio(dioOptions ?? BaseOptions()) {
     this.dio.interceptors.addAll([
       ...?interceptors,
       DioCacheInterceptor(


### PR DESCRIPTION
Fixes overrode `Dio.dioOptions` in the `CachedTileProvider`
#12

`Dio.dioOptions` are now taken into account when providing them to the `Dio`.

Backward compatibility is ensured when using deprecated param `CachedTileProvider.dioOptions` 