### PR TITLE
feat(vmt-pmtiles): support raster tiles from `PmTilesVectorTileProvider`, prepare `v1.2.0` release

### DIFF
--- a/example/lib/vector_map_tiles_pmtiles/page.dart
+++ b/example/lib/vector_map_tiles_pmtiles/page.dart
@@ -22,10 +22,7 @@ class VectorMapTilesPmTilesPage extends StatelessWidget {
     logger: kDebugMode ? const vtr.Logger.console() : null,
   );
 
-  final _futureTileProvider = PmTilesVectorTileProvider.fromSource(
-    tileSource,
-    silenceTileNotFound: true,
-  );
+  final _futureTileProvider = PmTilesVectorTileProvider.fromSource(tileSource);
 
   VectorMapTilesPmTilesPage({super.key});
 

--- a/vector_map_tiles_pmtiles/CHANGELOG.md
+++ b/vector_map_tiles_pmtiles/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.2.0] 2024-02-19
+
+- Update `vector_map_tiles` to version 7.3.0 and bump the dependency constraints
+  to `^7.3.0` (thanks to @greensopinion).
+- Deprecate `silenceTileNotFound` since it's not used anymore.
+
 ## [1.1.0] 2024-02-10
 
 - Add `ProtomapsThemes` with all Protomaps basemap themes.

--- a/vector_map_tiles_pmtiles/lib/src/vector_tile_provider.dart
+++ b/vector_map_tiles_pmtiles/lib/src/vector_tile_provider.dart
@@ -1,4 +1,5 @@
-import 'package:flutter/foundation.dart';
+import 'dart:typed_data';
+
 import 'package:pmtiles/pmtiles.dart';
 import 'package:vector_map_tiles/vector_map_tiles.dart';
 
@@ -6,20 +7,42 @@ import 'package:vector_map_tiles/vector_map_tiles.dart';
 /// PMTiles archive.
 ///
 class PmTilesVectorTileProvider extends VectorTileProvider {
+  /// Tile [PmTilesArchive] instance used to request tiles from.
   final PmTilesArchive archive;
+
+  /// The type of the tile provider.
+  ///
+  /// Either [TileProviderType.vector] or [TileProviderType.raster].
   @override
   final TileProviderType type;
 
+  @Deprecated(
+    'This option is no longer used and will get removed in a future update.',
+  )
+  final bool silenceTileNotFound;
+
   /// Create a tile provider directly with a [PmTilesArchive] from the
-  /// pmtiles package.
-  PmTilesVectorTileProvider.fromArchive(this.archive,
-      {this.type = TileProviderType.vector});
+  /// `pmtiles` package.
+  PmTilesVectorTileProvider.fromArchive(
+    this.archive, {
+    this.type = TileProviderType.vector,
+    @Deprecated(
+      'This option is no longer used and will get removed in a future update.',
+    )
+    this.silenceTileNotFound = false,
+  });
 
   /// Create a tile provider by specifying the source of the PMTiles file.
   ///
   /// [source] can either be a URL or path on your file system.
-  static Future<PmTilesVectorTileProvider> fromSource(String source,
-      {TileProviderType type = TileProviderType.vector}) async {
+  static Future<PmTilesVectorTileProvider> fromSource(
+    String source, {
+    TileProviderType type = TileProviderType.vector,
+    @Deprecated(
+      'This option is no longer used and will get removed in a future update.',
+    )
+    bool silenceTileNotFound = false,
+  }) async {
     final archive = await PmTilesArchive.from(source);
     return PmTilesVectorTileProvider.fromArchive(archive, type: type);
   }
@@ -41,9 +64,10 @@ class PmTilesVectorTileProvider extends VectorTileProvider {
       return Uint8List.fromList(data.bytes());
     } on TileNotFoundException {
       throw ProviderException(
-          message: 'Not found: $tile',
-          retryable: Retryable.none,
-          statusCode: 404);
+        message: 'Tile not found: $tile',
+        retryable: Retryable.none,
+        statusCode: 404,
+      );
     }
   }
 }

--- a/vector_map_tiles_pmtiles/pubspec.yaml
+++ b/vector_map_tiles_pmtiles/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
   pmtiles: ^1.2.0
-  vector_map_tiles: ^7.0.1
+  vector_map_tiles: ^7.3.0
   vector_tile_renderer: ^5.2.0
 
 dev_dependencies:

--- a/vector_map_tiles_pmtiles/pubspec.yaml
+++ b/vector_map_tiles_pmtiles/pubspec.yaml
@@ -3,7 +3,7 @@ description: PMTiles tile provider for vector_map_tiles (flutter_map vector tile
 repository: https://github.com/josxha/flutter_map_plugins
 issue_tracker: https://github.com/josxha/flutter_map_plugins/issues
 topics: [ flutter-map, vector-map-tiles, map, pmtiles ]
-version: 1.1.0
+version: 1.2.0
 
 environment:
   sdk: '>=3.2.5 <4.0.0'

--- a/vector_map_tiles_pmtiles/test/pmtiles_tile_provider_test.dart
+++ b/vector_map_tiles_pmtiles/test/pmtiles_tile_provider_test.dart
@@ -1,7 +1,6 @@
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pmtiles/pmtiles.dart';
 import 'package:vector_map_tiles/vector_map_tiles.dart';
 import 'package:vector_map_tiles_pmtiles/src/vector_tile_provider.dart';
 
@@ -12,11 +11,13 @@ Future<void> main() async {
     final mockPmTiles = MockPmTilesArchive();
     final provider = PmTilesVectorTileProvider.fromArchive(mockPmTiles);
     expect(provider.archive, equals(mockPmTiles));
+    expect(provider.type, TileProviderType.vector);
   });
   test('Create tile provider from source', () async {
     const source =
         'https://raw.githubusercontent.com/protomaps/PMTiles/main/spec/v3/protomaps(vector)ODbL_firenze.pmtiles';
     final provider = await PmTilesVectorTileProvider.fromSource(source);
+    expect(provider.type, TileProviderType.vector);
     expect(
       provider.archive.centerPosition.latitude,
       closeTo(43.779779, 0.001),
@@ -25,7 +26,6 @@ Future<void> main() async {
       provider.archive.centerPosition.longitude,
       closeTo(11.2414827, 0.001),
     );
-    expect(provider.silenceTileNotFound, isFalse);
     expect(provider.maximumZoom, equals(14));
     expect(provider.minimumZoom, equals(0));
     expect(
@@ -34,23 +34,27 @@ Future<void> main() async {
     );
     await expectLater(
       provider.provide(TileIdentity(10, 1, 1)),
-      throwsA(isA<TileNotFoundException>()),
+      throwsA(isA<ProviderException>()),
     );
   });
-  test('Create silenced tile provider', () async {
+  test('Ignores tiles that are not found', () async {
     const source =
         'https://raw.githubusercontent.com/protomaps/PMTiles/main/spec/v3/protomaps(vector)ODbL_firenze.pmtiles';
-    final provider = await PmTilesVectorTileProvider.fromSource(
-      source,
-      silenceTileNotFound: true,
-    );
+    final provider = await PmTilesVectorTileProvider.fromSource(source);
     expect(
       await provider.provide(TileIdentity(0, 0, 0)),
       isA<Uint8List>(),
     );
     await expectLater(
-      await provider.provide(TileIdentity(10, 1, 1)),
-      equals(Uint8List(0)),
+      provider.provide(TileIdentity(10, 1, 1)),
+      throwsA(isA<ProviderException>()),
     );
+  });
+
+  test('Accepts a type', () async {
+    final mockPmTiles = MockPmTilesArchive();
+    final provider = PmTilesVectorTileProvider.fromArchive(mockPmTiles,
+        type: TileProviderType.raster);
+    expect(provider.type, TileProviderType.raster);
   });
 }


### PR DESCRIPTION
Vector tiles can have raster layers. This change
adds support for TileProviderType.raster to
PmTilesVectorTileProvider.

Optional support for ignoring missing tiles was
removed, since there is no good way to return an
empty raster tile. Instead, library support for
missing tiles via ProviderException is leveraged.

Updated tests.