### PR TITLE
✨ feat(fm-cache): add `cachePolicy` parameter

### DIFF
--- a/flutter_map_cache/CHANGELOG.md
+++ b/flutter_map_cache/CHANGELOG.md
@@ -1,7 +1,8 @@
-## [1.5.0] 2024-02-10
+## [1.5.0] 2024-02-19
 
-- fix: assertion error when the total amount of bytes is unknown (Thanks to
+- fix: assertion error when the total amount of bytes is unknown (thanks to
   @Thelm76).
+- add: optional `cachePolicy` parameter (thanks to @Thelm76).
 
 ## [1.4.4] 2024-02-10
 
@@ -13,7 +14,7 @@
 
 - Fix: `CachedTileProvider.dio` had its `BaseOptions`
   overridden ([#12](https://github.com/josxha/flutter_map_plugins/issues/12),
-  Thanks to
+  thanks to
   @Thelm76)
 - Add tests
 
@@ -29,7 +30,7 @@
 ## [1.4.0] 2024-01-24
 
 - Add `dio` as a parameter to `CachedTileProvider`. You're now able to provide
-  and reuse your own Dio instance (Thanks to @PatrickWulfe).
+  and reuse your own Dio instance (thanks to @PatrickWulfe).
 - Deprecate the `dioOptions` parameter. Prefer creating your own Dio instance
   and provide it to the `dio` parameter.
 - Update the README file (for example add isar to the list of supported storage

--- a/flutter_map_cache/lib/src/cached_tile_provider.dart
+++ b/flutter_map_cache/lib/src/cached_tile_provider.dart
@@ -17,7 +17,7 @@ class CachedTileProvider extends TileProvider {
   /// Create a new [CachedTileProvider]
   CachedTileProvider({
     required CacheStore store,
-    cachePolicy = CachePolicy.forceCache,
+    CachePolicy cachePolicy = CachePolicy.forceCache,
     Dio? dio,
     @Deprecated(
       '''

--- a/flutter_map_cache/lib/src/cached_tile_provider.dart
+++ b/flutter_map_cache/lib/src/cached_tile_provider.dart
@@ -6,6 +6,9 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_cache/src/cached_image_provider.dart';
 
+export 'package:dio_cache_interceptor/dio_cache_interceptor.dart'
+    show CachePolicy;
+
 /// TileProvider with additional caching functionality
 class CachedTileProvider extends TileProvider {
   /// dio http client
@@ -14,6 +17,7 @@ class CachedTileProvider extends TileProvider {
   /// Create a new [CachedTileProvider]
   CachedTileProvider({
     required CacheStore store,
+    cachePolicy = CachePolicy.forceCache,
     Dio? dio,
     @Deprecated(
       '''
@@ -40,7 +44,7 @@ class CachedTileProvider extends TileProvider {
         options: CacheOptions(
           store: store,
           allowPostMethod: true,
-          policy: CachePolicy.forceCache,
+          policy: cachePolicy,
           maxStale: maxStale,
           keyBuilder: keyBuilder ?? CacheOptions.defaultCacheKeyBuilder,
           hitCacheOnErrorExcept: hitCacheOnErrorExcept,

--- a/flutter_map_cache/lib/src/cached_tile_provider.dart
+++ b/flutter_map_cache/lib/src/cached_tile_provider.dart
@@ -14,7 +14,10 @@ class CachedTileProvider extends TileProvider {
   /// dio http client
   final Dio dio;
 
-  /// Create a new [CachedTileProvider]
+  /// Create a new [CachedTileProvider].
+  ///
+  /// [cachePolicy] allows to set the policy used by the cache, see
+  /// [CachePolicy] from dio_cache_interceptor for more information.
   CachedTileProvider({
     required CacheStore store,
     CachePolicy cachePolicy = CachePolicy.forceCache,


### PR DESCRIPTION
Adding an optional parameter to `CachedTileProvider` so we can control the cache policy.

i.e. Here's API has cache headers in its responses, so in certain cases we may need to use the `refresh` or `request` cache policy.