### PR TITLE
🐛 fix(fm-cache): assertion error in `ImageProvider` if total bytes are unknown in `onReceiveProgress` callback.

### DIFF
--- a/flutter_map_cache/CHANGELOG.md
+++ b/flutter_map_cache/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.5.0] 2024-02-10
+
+- fix: assertion error when the total amount of bytes is unknown (Thanks to
+  @Thelm76).
+
 ## [1.4.4] 2024-02-10
 
 - Add web as supported platform

--- a/flutter_map_cache/lib/src/cached_image_provider.dart
+++ b/flutter_map_cache/lib/src/cached_image_provider.dart
@@ -81,12 +81,14 @@ class CachedImageProvider extends ImageProvider<CachedImageProvider> {
           headers: headers,
         ),
         onReceiveProgress: (count, total) {
-          chunkEvents.add(
-            ImageChunkEvent(
-              cumulativeBytesLoaded: count,
-              expectedTotalBytes: total,
-            ),
-          );
+          if (count >= 0) {
+            chunkEvents.add(
+              ImageChunkEvent(
+                cumulativeBytesLoaded: count,
+                expectedTotalBytes: total >= 0 ? total : null,
+              ),
+            );
+          }
         },
       );
       final bytes = Uint8List.fromList(response.data);

--- a/flutter_map_cache/lib/src/cached_image_provider.dart
+++ b/flutter_map_cache/lib/src/cached_image_provider.dart
@@ -81,14 +81,15 @@ class CachedImageProvider extends ImageProvider<CachedImageProvider> {
           headers: headers,
         ),
         onReceiveProgress: (count, total) {
-          if (count >= 0) {
-            chunkEvents.add(
-              ImageChunkEvent(
-                cumulativeBytesLoaded: count,
-                expectedTotalBytes: total >= 0 ? total : null,
-              ),
-            );
-          }
+          if (count < 1) return;
+          chunkEvents.add(
+            ImageChunkEvent(
+              cumulativeBytesLoaded: count,
+              // Dio returns -1 when the total amount of bytes are unknown while
+              // ImageChunkEvent expects null.
+              expectedTotalBytes: total < 0 ? null : total,
+            ),
+          );
         },
       );
       final bytes = Uint8List.fromList(response.data);


### PR DESCRIPTION
This PR adds filters in the `CachedImageProvider` in order to avoid the assertion errors throwed by the `ImageChunkEvent`

fyi : when the total response size is unknown by the Dio while executing a get method, the `total` parameter passed through the `onReceivedProgress` callback is -1, whereas `ImageChunkEvent` expects `null` in that case. 