### PR TITLE
feat: use vector_map_tiles v9 beta release

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -8,6 +8,8 @@ import 'package:flutter_map_plugins_example/flutter_map_maplibre/page.dart';
 import 'package:flutter_map_plugins_example/flutter_map_maplibre/page2.dart';
 import 'package:flutter_map_plugins_example/flutter_map_mbtiles/page.dart';
 import 'package:flutter_map_plugins_example/flutter_map_pmtiles/page.dart';
+import 'package:flutter_map_plugins_example/vector_map_tiles_mbtiles/page.dart';
+import 'package:flutter_map_plugins_example/vector_map_tiles_pmtiles/page.dart';
 import 'package:flutter_web_plugins/url_strategy.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
@@ -33,10 +35,10 @@ class MyApp extends StatelessWidget {
         '/flutter_map_pmtiles': (context) => const FlutterMapPmTilesPage(),
         '/flutter_map_maplibre': (context) => const MapLibreFlutterMapPage(),
         '/flutter_map_maplibre2': (context) => const FlutterMapMapLibrePage(),
-        // '/vector_map_tiles_pmtiles': (context) => VectorMapTilesPmTilesPage(),
+        '/vector_map_tiles_pmtiles': (context) => VectorMapTilesPmTilesPage(),
         '/flutter_map_mbtiles': (context) => const FlutterMapMbTilesPage(),
-        // '/vector_map_tiles_mbtiles': (context) =>
-        //     const VectorMapTilesMbTilesPage(),
+        '/vector_map_tiles_mbtiles': (context) =>
+            const VectorMapTilesMbTilesPage(),
         '/flutter_map_compass': (context) => const FlutterMapCompassPage(),
       },
     );
@@ -81,16 +83,16 @@ class SelectionPage extends StatelessWidget {
         desc: 'PMTiles for flutter_map',
         routeName: '/flutter_map_pmtiles',
       ),
-      // SelectionItemWidget.disabledOnWeb(
-      //   title: 'vector_map_tiles_mbtiles',
-      //   desc: 'MBTiles for vector_map_files / flutter_map',
-      //   routeName: '/vector_map_tiles_mbtiles',
-      // ),
-      // SelectionItemWidget.disabledOnWeb(
-      //   title: 'vector_map_tiles_pmtiles',
-      //   desc: 'PMTiles for vector_map_files / flutter_map',
-      //   routeName: '/vector_map_tiles_pmtiles',
-      // ),
+      SelectionItemWidget.disabledOnWeb(
+        title: 'vector_map_tiles_mbtiles',
+        desc: 'MBTiles for vector_map_files / flutter_map',
+        routeName: '/vector_map_tiles_mbtiles',
+      ),
+      SelectionItemWidget(
+        title: 'vector_map_tiles_pmtiles',
+        desc: 'PMTiles for vector_map_files / flutter_map',
+        routeName: '/vector_map_tiles_pmtiles',
+      ),
     ];
 
     final width = MediaQuery.sizeOf(context).width;

--- a/example/lib/vector_map_tiles_mbtiles/page.dart
+++ b/example/lib/vector_map_tiles_mbtiles/page.dart
@@ -1,4 +1,3 @@
-/*
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_plugins_example/common/utils.dart';
@@ -100,4 +99,3 @@ class _VectorMapTilesMbTilesPageState extends State<VectorMapTilesMbTilesPage> {
     super.dispose();
   }
 }
-*/

--- a/example/lib/vector_map_tiles_pmtiles/page.dart
+++ b/example/lib/vector_map_tiles_pmtiles/page.dart
@@ -1,4 +1,3 @@
-/*
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
@@ -69,4 +68,3 @@ class VectorMapTilesPmTilesPage extends StatelessWidget {
     );
   }
 }
-*/

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -23,8 +23,8 @@ dependencies:
   http_cache_file_store: ^2.0.0
   http_cache_hive_store: ^5.0.0
   sqlite3_flutter_libs: ^0.5.15
-  #  vector_map_tiles: ^8.0.0
-  # vector_tile_renderer: ^6.0.0
+  vector_map_tiles: ^9.0.0-beta.8
+  vector_tile_renderer: ^6.0.0
   mbtiles: ^0.4.0
   maplibre: ^0.2.0
 
@@ -38,10 +38,10 @@ dependencies:
     path: ../flutter_map_mbtiles
   flutter_map_pmtiles:
     path: ../flutter_map_pmtiles
-#  vector_map_tiles_mbtiles:
-#    path: ../vector_map_tiles_mbtiles
-#  vector_map_tiles_pmtiles:
-#    path: ../vector_map_tiles_pmtiles
+  vector_map_tiles_mbtiles:
+    path: ../vector_map_tiles_mbtiles
+  vector_map_tiles_pmtiles:
+    path: ../vector_map_tiles_pmtiles
 
 dev_dependencies:
   very_good_analysis: ^7.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,5 +9,5 @@ workspace:
   - flutter_map_maplibre
   - flutter_map_mbtiles
   - flutter_map_pmtiles
-#  - vector_map_tiles_mbtiles
-#  - vector_map_tiles_pmtiles
+  - vector_map_tiles_mbtiles
+  - vector_map_tiles_pmtiles

--- a/vector_map_tiles_mbtiles/lib/src/vector_tile_provider.dart
+++ b/vector_map_tiles_mbtiles/lib/src/vector_tile_provider.dart
@@ -1,4 +1,3 @@
-/*
 import 'dart:typed_data';
 
 import 'package:mbtiles/mbtiles.dart';
@@ -67,4 +66,3 @@ class MbTilesVectorTileProvider extends VectorTileProvider {
   @override
   TileOffset get tileOffset => TileOffset.DEFAULT;
 }
-*/

--- a/vector_map_tiles_mbtiles/lib/vector_map_tiles_mbtiles.dart
+++ b/vector_map_tiles_mbtiles/lib/vector_map_tiles_mbtiles.dart
@@ -1,1 +1,1 @@
-// export 'src/vector_tile_provider.dart';
+export 'src/vector_tile_provider.dart';

--- a/vector_map_tiles_mbtiles/pubspec.yaml
+++ b/vector_map_tiles_mbtiles/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   flutter:
     sdk: flutter
   mbtiles: ^0.4.0
-  vector_map_tiles: ^8.0.0
+  vector_map_tiles: ^9.0.0-beta.8
 
 dev_dependencies:
   flutter_test:
@@ -28,4 +28,4 @@ dev_dependencies:
   latlong2: ^0.9.0
   flutter_map: ^8.0.0
   very_good_analysis: ^7.0.0
-  vector_tile_renderer: ^5.2.0
+  vector_tile_renderer: ^6.0.0

--- a/vector_map_tiles_pmtiles/lib/src/themes/protomaps_themes.dart
+++ b/vector_map_tiles_pmtiles/lib/src/themes/protomaps_themes.dart
@@ -1,4 +1,3 @@
-/*
 import 'package:vector_map_tiles_pmtiles/src/themes/v3/_package.dart' as v3;
 import 'package:vector_map_tiles_pmtiles/src/themes/v4/_package.dart' as v4;
 import 'package:vector_tile_renderer/vector_tile_renderer.dart';
@@ -123,4 +122,3 @@ class ProtomapsThemes {
         sprites: 'https://protomaps.github.io/basemaps-assets/sprites/v4/white',
       ).build(v4.themeWhite);
 }
-*/

--- a/vector_map_tiles_pmtiles/lib/src/vector_tile_provider.dart
+++ b/vector_map_tiles_pmtiles/lib/src/vector_tile_provider.dart
@@ -1,4 +1,3 @@
-/*
 import 'dart:typed_data';
 
 import 'package:pmtiles/pmtiles.dart';
@@ -77,4 +76,3 @@ class PmTilesVectorTileProvider extends VectorTileProvider {
   @override
   TileOffset get tileOffset => TileOffset.DEFAULT;
 }
-*/

--- a/vector_map_tiles_pmtiles/lib/vector_map_tiles_pmtiles.dart
+++ b/vector_map_tiles_pmtiles/lib/vector_map_tiles_pmtiles.dart
@@ -1,4 +1,2 @@
-/*
 export 'src/themes/protomaps_themes.dart';
 export 'src/vector_tile_provider.dart';
-*/

--- a/vector_map_tiles_pmtiles/pubspec.yaml
+++ b/vector_map_tiles_pmtiles/pubspec.yaml
@@ -17,8 +17,8 @@ dependencies:
   flutter:
     sdk: flutter
   pmtiles: ^1.2.0
-  vector_map_tiles: ^8.0.0
-  vector_tile_renderer: ^5.2.0
+  vector_map_tiles: ^9.0.0-beta.8
+  vector_tile_renderer: ^6.0.0
 
 dev_dependencies:
   build_runner: ^2.4.8


### PR DESCRIPTION
The vector_map_tiles 9.0.0-beta.8 release has support for flutter_map v8, let's use it.