### PR TITLE
Add missing headers from constructor

### DIFF
--- a/flutter_map_cache/lib/src/cached_tile_provider.dart
+++ b/flutter_map_cache/lib/src/cached_tile_provider.dart
@@ -16,8 +16,8 @@ class CachedTileProvider extends TileProvider {
   /// [cachePolicy] allows to set the policy used by the cache, see
   /// [CachePolicy] from dio_cache_interceptor for more information.
   CachedTileProvider({
-    super.headers,
     required CacheStore store,
+    super.headers,
     CachePolicy cachePolicy = CachePolicy.forceCache,
     Dio? dio,
     List<Interceptor>? interceptors,

--- a/flutter_map_cache/lib/src/cached_tile_provider.dart
+++ b/flutter_map_cache/lib/src/cached_tile_provider.dart
@@ -16,6 +16,7 @@ class CachedTileProvider extends TileProvider {
   /// [cachePolicy] allows to set the policy used by the cache, see
   /// [CachePolicy] from dio_cache_interceptor for more information.
   CachedTileProvider({
+    super.headers,
     required CacheStore store,
     CachePolicy cachePolicy = CachePolicy.forceCache,
     Dio? dio,


### PR DESCRIPTION
### DESCRIPTION

- Added missing `super` call to headers in `CachedTitleProvider`.